### PR TITLE
mac80211: mwl8k: expand 5G channels above 48.

### DIFF
--- a/package/kernel/mac80211/patches/941-mwl8k_expand_5g_channels.patch
+++ b/package/kernel/mac80211/patches/941-mwl8k_expand_5g_channels.patch
@@ -1,0 +1,39 @@
+--- a/drivers/net/wireless/marvell/mwl8k.c
++++ b/drivers/net/wireless/marvell/mwl8k.c
+@@ -199,7 +199,7 @@
+ 	struct ieee80211_channel channels_24[14];
+ 	struct ieee80211_rate rates_24[13];
+ 	struct ieee80211_supported_band band_50;
+-	struct ieee80211_channel channels_50[4];
++	struct ieee80211_channel channels_50[25];
+ 	struct ieee80211_rate rates_50[8];
+ 	u32 ap_macids_supported;
+ 	u32 sta_macids_supported;
+@@ -383,6 +383,27 @@
+ 	{ .band = NL80211_BAND_5GHZ, .center_freq = 5200, .hw_value = 40, },
+ 	{ .band = NL80211_BAND_5GHZ, .center_freq = 5220, .hw_value = 44, },
+ 	{ .band = NL80211_BAND_5GHZ, .center_freq = 5240, .hw_value = 48, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5260, .hw_value = 52, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5280, .hw_value = 56, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5300, .hw_value = 60, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5320, .hw_value = 64, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5500, .hw_value = 100, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5520, .hw_value = 104, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5540, .hw_value = 108, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5560, .hw_value = 112, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5580, .hw_value = 116, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5600, .hw_value = 120, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5620, .hw_value = 124, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5640, .hw_value = 128, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5660, .hw_value = 132, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5680, .hw_value = 136, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5700, .hw_value = 140, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5720, .hw_value = 144, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5745, .hw_value = 149, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5765, .hw_value = 153, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5785, .hw_value = 157, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5805, .hw_value = 161, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5825, .hw_value = 165, },
+ };
+ 
+ static const struct ieee80211_rate mwl8k_rates_50[] = {


### PR DESCRIPTION
Signed-off-by: Weixiao Zhang <waveletboy@gmail.com>

Thanks for your contribution to the LEDE project!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://lede-project.org/submitting-patches

Please remove this message before posting the pull request.
